### PR TITLE
Get referral server by name

### DIFF
--- a/registrars.json
+++ b/registrars.json
@@ -1,0 +1,3 @@
+{
+  "Name.com / Dave McBreen": "whois.name.com"
+}


### PR DESCRIPTION
In some cases whois response does not contain referral server address but name of referral. This change will try to find whois server in local catalog.